### PR TITLE
bumping version to 2.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,13 @@ pluginBundle {
     vcsUrl = 'https://github.com/browserstack/browserstack-gradle-plugin'
 
     plugins {
-        myTestPluginInfo {
+        browserstackPlugin {
             id = 'com.browserstack.gradle'
             displayName = 'BrowserStack\'s Gradle Plugin'
             description = 'Runs Espresso tests on BrowserStack'
-            tags = ['espresso', 'test', 'browserstack', 'app', 'automate', 'app-automate', 'appautomate']
-            version = '2.2.0'
+            tags = ['espresso', 'test', 'browserstack', 'app', 'automate', 
+                'app-automate', 'appautomate', 'app-live', 'applive']
+            version = '2.3.0'
         }
     }
 }


### PR DESCRIPTION
Changes in build.gradle:
1.  Version bump to 2.3.0.
2.  Fixed name of plugin in pluginBundle.
3.  Added app live tags
