### PR TITLE
added spoon framework variable set

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:2.3.2"
+    classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:2.3.3"
   }
 }
 
@@ -114,7 +114,7 @@ gradle clean upload${buildVariantName}ToBrowserstackAppLive
 For running tests on a project with no variants, you can simply run following command for uploading debug apk:
 
 ```
-gradle clean uploadDebugToBrowserstackAppLive 
+gradle clean uploadDebugToBrowserstackAppLive
 ```
 
 And for projects with productFlavors, replace ${buildVariantName} with your build variant name, for example if your productFlavor name is "phone" and you want to upload debug build type of this variant then command will be gradle clean uploadPhoneDebugToBrowserstackAppLive.
@@ -131,7 +131,7 @@ And for projects with productFlavors, replace ${buildVariantName} with your buil
  1. Build debug and test apks, as dependencies are declared on `assemble${buildvariantName}` .
  2. Find the latest apk in the app directory recursively.
  3. Upload the apk on BrowserStack AppLive platform.
- 
+
 
 > Note: You can also set the values of username and accessKey in environment variables with names BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY, respectively. If you do this, then there is no need to set these parameters in browserStackConfig block.
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.9.10'
 }
 
-version '2.3.2'
+version '2.3.3'
 
 pluginBundle {
     website = 'https://www.browserstack.com'
@@ -14,9 +14,9 @@ pluginBundle {
             id = 'com.browserstack.gradle'
             displayName = 'BrowserStack\'s Gradle Plugin'
             description = 'Runs Espresso tests on BrowserStack'
-            tags = ['espresso', 'test', 'browserstack', 'app', 'automate', 
+            tags = ['espresso', 'test', 'browserstack', 'app', 'automate',
                 'app-automate', 'appautomate', 'app-live', 'applive']
-            version = '2.3.2'
+            version = '2.3.3'
         }
     }
 }

--- a/src/main/java/com/browserstack/gradle/BrowserStackPlugin.java
+++ b/src/main/java/com/browserstack/gradle/BrowserStackPlugin.java
@@ -101,6 +101,8 @@ public class BrowserStackPlugin implements Plugin<Project> {
           System.out.println("ERROR: " + e.getMessage());
           System.exit(1);
         }
+
+        task.setEnableSpoonFramework(browserStackConfigExtension.getEnableSpoonFramework());
         task.setTimezone(browserStackConfigExtension.getTimezone());
         task.setCustomBuildName(browserStackConfigExtension.getCustomBuildName());
         task.setCustomBuildNotifyURL(browserStackConfigExtension.getCustomBuildNotifyURL());


### PR DESCRIPTION
Current gradle plugin does not capture the spoon framework variable "enableSpoonFramework = true" from the parent Espresso app. Updating the plugin to use the variable to avoid failures in BrowserStack Espresso Apps execution using spoon framework.