### PR TITLE
Make Browserstack gradle plugin compatible with gradle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:3.0.2"
+    classpath "gradle.plugin.com.browserstack.gradle:browserstack-gradle-plugin:3.0.3"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.11.0'
 }
 
-version '3.0.2'
+version '3.0.3'
 
 pluginBundle {
     website = 'https://www.browserstack.com'
@@ -17,7 +17,7 @@ pluginBundle {
             description = 'Runs Espresso tests on BrowserStack'
             tags = ['espresso', 'test', 'browserstack', 'app', 'automate',
                 'app-automate', 'appautomate', 'app-live', 'applive']
-            version = '3.0.2'
+            version = '3.0.3'
         }
     }
 }

--- a/src/main/java/com/browserstack/gradle/BrowserStackTask.java
+++ b/src/main/java/com/browserstack/gradle/BrowserStackTask.java
@@ -21,6 +21,7 @@ public class BrowserStackTask extends DefaultTask {
   @Input
   private String username, accessKey;
 
+  @Input
   private String app, host;
 
   private String appVariantBaseName = "debug";

--- a/test.rb
+++ b/test.rb
@@ -1,4 +1,4 @@
-PLUGIN_JAR_PATH=`pwd`.strip+"/build/libs/browserstack-gradle-plugin-3.0.2.jar"
+PLUGIN_JAR_PATH=`pwd`.strip+"/build/libs/browserstack-gradle-plugin-3.0.3.jar"
 PWD=`pwd`.strip
 
 def run_command(s)


### PR DESCRIPTION
Make Browserstack gradle plugin compatible with gradle 7. 
We used to get this error 

`A problem was found with the configuration of task ':app:executeMeeticExternalDebugTestsOnBrowserstack' (type 'EspressoTask').
  - Type 'EspressoTask' property 'host' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.0/userguide/validation_problems.html#missing_annotation for more details about this problem. `
