### PR TITLE
Add command line param to skip rebuilding espresso apks and testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Builds, uploads and start Espresso tests on BrowserStack AppAutomate.
 
 gradle clean execute${buildVariantName}TestsOnBrowserstack
 
-For running tests on a project with no variants, you can simply run following command for uploading and running tests on debug apk:
+For running tests on a project with no variants, you can simply run following command for building, uploading and running tests on debug apk:
 
 ```
 gradle clean executeDebugTestsOnBrowserstack
@@ -77,6 +77,12 @@ And for projects with productFlavors, replace ${buildVariantName} with your buil
 ```
 gradle clean executePhoneDebugTestsOnBrowserstack
 
+```
+
+For running tests on a project without rebuilding apk and test suite, you can simply run following command for uploading and running tests on debug apk:
+
+```
+gradle executeDebugTestsOnBrowserstack -PskipBuildingApks=true
 ```
 
 ##### Supported browserStackConfig parameters

--- a/src/main/java/com/browserstack/gradle/BrowserStackPlugin.java
+++ b/src/main/java/com/browserstack/gradle/BrowserStackPlugin.java
@@ -36,7 +36,10 @@ public class BrowserStackPlugin implements Plugin<Project> {
       project.getTasks().create("execute" + appVariantName + "TestsOnBrowserstack", EspressoTask.class, (task) -> {
         task.setGroup(DEFAULT_GROUP);
         task.setDescription("Uploads app / tests to AppAutomate and executes them");
-        task.dependsOn("assemble" + appVariantName, "assemble" + appVariantName + "AndroidTest");
+        // Run Espresso tests without building the apk and test apk
+        if (!project.hasProperty("skipBuildingApks") ) {
+          task.dependsOn("assemble" + appVariantName, "assemble" + appVariantName + "AndroidTest");
+        }
         task.setAppVariantBaseName(applicationVariant.getBaseName());
         task.setUsername(browserStackConfigExtension.getUsername());
         task.setAccessKey(browserStackConfigExtension.getAccessKey());

--- a/test.rb
+++ b/test.rb
@@ -58,6 +58,7 @@ end
 def run_tests_args
   puts "\nRunning new tests using ./gradlew with args"
   run_basic_espresso_test("./gradlew clean executeDebugTestsOnBrowserstack --config-file='command-line-config-browserstack.json'")
+  run_basic_espresso_test("./gradlew executeDebugTestsOnBrowserstack -PskipBuildingApks=true")
   print_separator
 end
 


### PR DESCRIPTION
Add command line param to skip rebuilding espresso apks and testsuite

`skipBuildingApks`

Usage

```
./gradlew executeDebugTestsOnBrowserstack -PskipBuildingApks=true
```